### PR TITLE
Added an error message when directories (like cache/) could not be writt...

### DIFF
--- a/src/Microweber/includes/install/index.php
+++ b/src/Microweber/includes/install/index.php
@@ -31,7 +31,10 @@ function __mw_install_log($text)
 {
     if (defined('MW_CACHE_ROOT_DIR')) {
         if (!is_dir(MW_CACHE_ROOT_DIR)) {
-            mkdir(MW_CACHE_ROOT_DIR);
+			if (mkdir(MW_CACHE_ROOT_DIR) == false)
+			{
+				echo "<div>Couldn't create directory: " . MW_CACHE_ROOT_DIR . "</div>\n";
+			}
         }
     }
     $log_file = MW_CACHE_ROOT_DIR . DIRECTORY_SEPARATOR . 'install_log.txt';


### PR DESCRIPTION
Added an error message when directories (like cache/) could not be written to during installation.

The cache/ dir not being writeable broke my installation and I had no clue why it was broken until I added this debug information.
