### PR TITLE
Fix of data loss with checkbox in contact form

### DIFF
--- a/src/Microweber/Db.php
+++ b/src/Microweber/Db.php
@@ -2738,7 +2738,7 @@ if (is_string($k)){
                 if (is_array($v)) {
                     $v = $this->addslashes_array($v);
                 } else {
-                    if ($k == 'id') {
+                    if ($k === 'id') {
                         $v = intval($v);
                     } else {
                         $v = addslashes($v);


### PR DESCRIPTION
Update in relation of ticket #228
If we complete checkbox data in contact-form, bdd save 0 instead of real value (only for the first item).
Set === instead of == seems to fix the bug
