### PR TITLE
Fix IE 7 bug

### DIFF
--- a/src/Microweber/includes/api/tools.js
+++ b/src/Microweber/includes/api/tools.js
@@ -2544,7 +2544,7 @@ mw.tools = {
            left: 'auto',
            top: mw.tools.TemplateSettingsModalDefaults.top,
            height:'auto',
-           zIndex:1102,
+           zIndex:1102
         }).addClass('mw-template-settings-hidden');
 
         mw.$('.mw_modal_container', $(modal.main)[0]).height('auto');


### PR DESCRIPTION
In Internet Explorer 7 JS is broken due to unnecessary comma
