### PR TITLE
Update address.php

### DIFF
--- a/userfiles/modules/microweber/custom_fields/address.php
+++ b/userfiles/modules/microweber/custom_fields/address.php
@@ -52,7 +52,6 @@ if(is_array($data['values']) and isset($data['options']) and is_array($data['opt
   <label class="mw-ui-label mw-address-label">
     <?php _e($data['name']) ?>
   </label>
-  <?php elseif (isset($data['name']) == true and $data['name'] != ''): ?>
   <?php else : ?>
   <?php endif; ?>
   <?php if (isset($data['help']) == true and $data['help'] != ''): ?>


### PR DESCRIPTION
spotted a redundancy in the code, while trying to locate address custom-field template code. Are there any reason for custom fields file not using template system like other modules? I feel like it would be much nicer if user can modify these files as well as other module template, some people might want to customize shipping address custom fields array to other orders, such as "address/city/zipcode/state/country" or any other orders they wish to place.