### PR TITLE
Fixed issue #388 - boostrap carousel indices are one off in picture gallery module

### DIFF
--- a/userfiles/templates/default/modules/pictures/templates/bootstrap_carousel.php
+++ b/userfiles/templates/default/modules/pictures/templates/bootstrap_carousel.php
@@ -20,7 +20,7 @@ description: Bootstrap Carousel
     <div id="<?php print $id; ?>" class="carousel slide mw-image-carousel">
       <ol class="carousel-indicators">
         <?php $count = -1; foreach($data  as $item): ?>
-        <li data-target="#<?php print $id; ?>" data-slide-to="<?php print $count++; ?>" class="<?php if($count==0){ print 'active';} ?>"></li>
+        <li data-target="#<?php print $id; ?>" data-slide-to="<?php print ++$count; ?>" class="<?php if($count==0){ print 'active';} ?>"></li>
         <?php endforeach; ?>
       </ol>
     <!-- Carousel items -->

--- a/userfiles/templates/liteness/modules/pictures/templates/bootstrap_carousel.php
+++ b/userfiles/templates/liteness/modules/pictures/templates/bootstrap_carousel.php
@@ -20,7 +20,7 @@ description: Bootstrap Carousel
     <div id="<?php print $id; ?>" class="carousel slide mw-image-carousel">
       <ol class="carousel-indicators">
         <?php $count = -1; foreach($data  as $item): ?>
-        <li data-target="#<?php print $id; ?>" data-slide-to="<?php print $count++; ?>" class="<?php if($count==0){ print 'active';} ?>"></li>
+        <li data-target="#<?php print $id; ?>" data-slide-to="<?php print ++$count; ?>" class="<?php if($count==0){ print 'active';} ?>"></li>
         <?php endforeach; ?>
       </ol>
     <!-- Carousel items -->


### PR DESCRIPTION
The counter was initialised at -1 and then post-incremented, resulting in array indices being one off.  If the counter is pre-incremented before use, then everything works correctly.