### PR TITLE
#472_fix_json_decode_null

### DIFF
--- a/userfiles/modules/cookie_notice/admin.php
+++ b/userfiles/modules/cookie_notice/admin.php
@@ -70,7 +70,7 @@ $defaults = array(
         'code' => '')
 );
 
-$json = json_decode($settings, true);
+$json = array_wrap(json_decode($settings, true));
 $json = array_merge($defaults, $json);
 if (isset($json) == false or count($json) == 0) {
     $json = $defaults;


### PR DESCRIPTION
when $json decode get null, force $json to be array .