### PR TITLE
Ezyweb.uk popup module proposed updates

### DIFF
--- a/userfiles/modules/microweber/toolbar/editor_tools/link_editor/index.php
+++ b/userfiles/modules/microweber/toolbar/editor_tools/link_editor/index.php
@@ -37,7 +37,8 @@
                         return false;
                     }
                 }
-                mw.tools.ajaxSearch({keyword: val, limit: 4}, function () {
+                // is_active: 'y' fails + is a limit required?
+                mw.tools.ajaxSearch({keyword: val, limit: 20}, function () {
                     var lis = [];
                     var json = this;
                     var createLi = function(obj){
@@ -120,6 +121,10 @@
 
     #tabs .tab {
         display: none;
+    }
+
+    #mw-popup-insertlink {
+        overflow:auto;
     }
 
     .mw-ui-row-nodrop, .media-search-holder {

--- a/userfiles/modules/microweber/toolbar/editor_tools/rte_link_editor/index.php
+++ b/userfiles/modules/microweber/toolbar/editor_tools/rte_link_editor/index.php
@@ -33,7 +33,8 @@
                         return false;
                     }
                 }
-                mw.tools.ajaxSearch({keyword: val, limit: 4}, function () {
+                // param is_active:'y' breaks search + is a limit required?
+                mw.tools.ajaxSearch({keyword: val, limit: 20}, function () {
                     var lis = "";
                     var json = this;
                     for (var item in json) {
@@ -185,6 +186,7 @@
 
     #mw-popup-insertlink {
         padding: 10px;
+        overflow:auto;
     }
 
     .mw-ui-row-nodrop, .media-search-holder {

--- a/userfiles/modules/popup/admin.php
+++ b/userfiles/modules/popup/admin.php
@@ -2,27 +2,98 @@
 
 <?php
 $type = get_option('type', $params['id']);
+$link_text = get_option('link_text', $params['id']);
+$source = get_option('source', $params['id']);
+$page_id = get_option('page_id', $params['id']);
 $time_delay = get_option('time_delay', $params['id']);
 if (!$time_delay) {
     $time_delay = 3000;
 }
+
+// TODO: fix module refresh on closing settings
 ?>
 
-<script>
-    function showHideDelay() {
-        var selectedType = $('input[name="type"]:checked').val();
-        if (selectedType == 'on_time') {
-            $('.js-time-delay').show();
-        } else {
-            $('.js-time-delay').hide();
-        }
+<script type="text/javascript">
+    is_searching = false;
+    mw.dd_autocomplete = function (id, selected_page_id = false) {
+        var el = $(id);
+            if (!is_searching) {
+                var val = el.val();
+                // NB: param is_active: 'y', - fails
+                mw.tools.ajaxSearch({keyword: val, content_type: 'page', order_by: 'title', limit: 20}, function () {
+                    var lis = "";
+                    var json = this;
+                    var title = "";
+                    var page_id = "";
+                    var sel_title = ""
+                    for (var item in json) {
+                        var obj = json[item];
+                        if (typeof obj === 'object') {
+                            title = obj.title;
+                            page_id = obj.id;
+                            if(selected_page_id && selected_page_id == page_id){
+                            	sel_title = title;
+                            }
+                            lis += "<li class='mw-dd-list-result' value='" + title + "' onclick='setACValue(\"" + page_id + "\",\"" + title + "\")'><a href='javascript:;'>" + title + "</a></li>";
+                        }
+                    }
+                    var ul = el.parent().find("ul");
+                    ul.find("li:gt(0)").remove();
+                    ul.append(lis);
+                    if(sel_title){
+                    	$("#dd_pages_search").val(sel_title);
+                        $('#page_id_field').val(page_id);
+                    }
+                });
+            }
+    }
+
+    setACValue = function (page_id,title) {
+		$("#dd_pages_search").val(title);
+		$('#page_id_field').val(page_id).trigger('change');
+    };
+
+    function showHideFields(fieldset) {
+        if(fieldset=='type') {
+			var selectedType = $('input[name="type"]:checked').val();
+			if (selectedType == 'on_time') {
+				$('.js-time-delay').show();
+				$('.link_text').hide();
+			} else if (selectedType == 'on_click') {
+				$('.js-time-delay').hide();
+				$('.link_text').show();
+			} else {
+			    $('.js-time-delay').hide();
+			    $('.link_text').hide();
+			}
+		} else if(fieldset=='source') {
+			var selectedType = $('input[name="source"]:checked').val();
+			if (selectedType == 'existing_page') {
+				$('.popup_page_id').show();
+			} else {
+				$('.popup_page_id').hide();
+			}
+		}
     }
     $(document).ready(function () {
-        showHideDelay();
-
+        showHideFields('type');
         $('input[name="type"]').on('change', function () {
-            showHideDelay();
+            showHideFields('type');
         });
+        showHideFields('source');
+        $('input[name="source"]').on('change', function () {
+            showHideFields('source');
+        });
+
+        mw.tools.dropdown();
+
+		<?php if(!empty($page_id)): ?>
+		var selected_page_id = <?php print $page_id;?>
+		<?php else: ?>
+		var selected_page_id = false;
+		<?php endif; ?>
+
+        mw.dd_autocomplete('#dd_pages_search', selected_page_id);
     });
 </script>
 
@@ -30,6 +101,9 @@ if (!$time_delay) {
     .module-popup-settings .mw-ui-inline-list li {
         list-style: none;
         margin-bottom: 10px;
+    }
+    #insert_link_list {
+        width: 100%;
     }
 </style>
 <div class="mw-modules-tabs">
@@ -43,22 +117,25 @@ if (!$time_delay) {
             <div class="module-live-edit-settings module-popup-settings">
                 <div class="mw-ui-field-holder">
                     <label class="mw-ui-label"><?php _e("Show Pop-Up event"); ?></label>
-
                     <ul class="mw-ui-inline-list">
                         <li>
                             <label class="mw-ui-check">
                                 <input type="radio" name="type" class="mw_option_field" value="on_click" data-refresh="popup"
-                                       <?php if ($type == 'on_click'): ?>checked<?php endif; ?>><span></span><span>On click</span>
+                                       <?php if ($type == 'on_click'): ?>checked<?php endif; ?>><span></span><span>On click link</span>
                             </label>
                         </li>
-
+                        <li>
+                            <label class="mw-ui-check">
+                                <input type="radio" name="type" class="mw_option_field" value="on_click_host" data-refresh="popup"
+                                       <?php if ($type == 'on_click_host'): ?>checked<?php endif; ?>><span></span><span>On click host link (<span class="tip" data-tipposition="top-center" title="Use nearest preceding link">?</span>)</span>
+                            </label>
+                        </li>
                         <li>
                             <label class="mw-ui-check">
                                 <input type="radio" name="type" class="mw_option_field" value="on_time" data-refresh="popup"
                                        <?php if ($type == 'on_time'): ?>checked<?php endif; ?>><span></span><span>On time (<span class="tip" data-tipposition="top-center" title="Only first time (if accept) with cookies">?</span>)</span>
                             </label>
                         </li>
-
                         <li>
                             <label class="mw-ui-check">
                                 <input type="radio" name="type" class="mw_option_field" value="on_leave_window" data-refresh="popup"
@@ -68,11 +145,49 @@ if (!$time_delay) {
                     </ul>
                 </div>
 
+                <div class="mw-ui-field-holder link_text">
+                    <label class="mw-ui-label"><?php _e("Link text"); ?></label>
+                    <input type="text" name="link_text" class="mw_option_field mw-ui-field mw-full-width" value="<?php print $link_text; ?>" data-refresh="popup"/>
+                </div>
+
                 <div class="mw-ui-field-holder js-time-delay" style="display: none;">
                     <label class="mw-ui-label"><?php _e("Time delay in MS"); ?></label>
                     <input type="text" name="time_delay" class="mw_option_field mw-ui-field mw-full-width" value="<?php print $time_delay; ?>" data-refresh="popup"/>
                     <small><?php _e("Only if Show Pop-Up Event is On time"); ?></small>
                 </div>
+
+                <div class="mw-ui-field-holder">
+                    <label class="mw-ui-label"><?php _e("Content source"); ?></label>
+                    <ul class="mw-ui-inline-list">
+                        <li>
+                            <label class="mw-ui-check">
+                                <input type="radio" name="source" class="mw_option_field" value="edited_text" data-refresh="popup"
+                                		<?php if ($source == 'edited_text'): ?>checked<?php endif; ?>><span></span><span>Edited text (<span class="tip" data-tipposition="top-center" title="Open the popup to edit the text">?</span>)</span>
+                            </label>
+                        </li>
+                        <li>
+                            <label class="mw-ui-check">
+                                <input type="radio" name="source" class="mw_option_field" value="existing_page" data-refresh="popup"
+                                		<?php if ($source == 'existing_page'): ?>checked<?php endif; ?>><span></span><span>Existing page content</span>
+                            </label>
+                        </li>
+                    </ul>
+                </div>
+
+                <div id="popup_url_holder" class="mw-ui-field-holder popup_page_id">
+                    <label class="mw-ui-label"><?php _e("Select existing page for popup content"); ?></label>
+                    <div data-value="<?php print site_url(); ?>" id="insert_link_list" class="mw-dropdown mw-dropdown-default active">
+                        <input type="hidden" class="mw_option_field" name="page_id" id="page_id_field"/>
+                        <input type="text" class="mw-ui-field inactive" id="dd_pages_search" autocomplete="off" placeholder="<?php _e("Click to select"); ?>"/>
+                        <span class="mw-icon-dropdown"></span>
+                        <div class="mw-dropdown-content">
+                            <ul class="">
+                                <li class="other-action" value="-1" style="display: none;"></li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+
             </div>
         </div>
     </div>

--- a/userfiles/modules/popup/config.php
+++ b/userfiles/modules/popup/config.php
@@ -7,4 +7,4 @@ $config['no_cache'] = false;
 $config['ui'] = true;
 $config['categories'] = "other";
 $config['position'] = 36;
-$config['version'] = 1;
+$config['version'] = 1.1;

--- a/userfiles/modules/popup/functions.php
+++ b/userfiles/modules/popup/functions.php
@@ -1,0 +1,8 @@
+<?php
+api_expose('popup_module_get_content_by_id');
+function popup_module_get_content_by_id(){
+    $page_id = $_GET['page_id'];
+    //$page_id = $_POST['page_id'];
+    return get_content_by_id($page_id);
+}
+?>

--- a/userfiles/modules/popup/index.php
+++ b/userfiles/modules/popup/index.php
@@ -1,14 +1,19 @@
 <?php
 $type = get_option('type', $params['id']);
+$link_text = get_option('link_text', $params['id']);
+if(!$link_text) $link_text = 'Click to open modal';
+$source = get_option('source', $params['id']);
+if(!$source) $source = 'edited_text';
+$page_id = get_option('page_id', $params['id']);
+
 $time_delay = get_option('time_delay', $params['id']);
 if (!$time_delay) {
     $time_delay = 3000;
 }
-?>
 
 
-<?php if ($type == 'on_time'): ?>
-    <?php $session_get = false;
+if ($type == 'on_time'):
+    $session_get = false;
     $modal_id = 'popup-' . $params['id'];
     if (isset($_COOKIE['popup-' . $params['id']])) {
         $session_get = $_COOKIE['popup-' . $params['id']];
@@ -19,20 +24,20 @@ if (!$time_delay) {
     } else {
         $showPopUp = false;
     }
-    ?>
 
-    <?php if ($showPopUp): ?>
+    if ($showPopUp): ?>
         <script>
             $(window).on('load', function () {
-
                 <?php if (in_live_edit()): ?>
                 $('#popup-<?php print $params['id']; ?>').modal({backdrop: false});
                 <?php else: ?>
                 setTimeout(function () {
+					<?php if($source == 'existing_page' && !empty($page_id)): ?>
+					popup_get_content();
+					<?php endif;?>
                     $('#popup-<?php print $params['id']; ?>').modal('show');
                 }, <?php print $time_delay; ?>);
                 <?php endif; ?>
-
             });
         </script>
     <?php endif; ?>
@@ -45,48 +50,93 @@ if (!$time_delay) {
             });
         });
     </script>
-<?php elseif ($type == 'on_leave_window'): ?>
-    <?php $session_get = false;
-    $modal_id = 'popup-' . $params['id'];
-    if (isset($_COOKIE['popup-' . $params['id']])) {
-        $session_get = $_COOKIE['popup-' . $params['id']];
-    }
-
-    if ($session_get != 'yes') {
-        $showPopUp = true;
-    } else {
-        $showPopUp = false;
-    }
-    ?>
-
-    <?php if ($showPopUp): ?>
-        <style>
-            .on_leave_window {
-                z-index: 99999;
-                height: 2px;
-                top: 0;
-                width: 100%;
-                position: fixed;
-                /*border: 1px solid red;*/
-            }
-        </style>
-        <script>
-            $(document).ready(function () {
-                setTimeout(function () {
-                    $('body').append('<div class="on_leave_window"></div>');
-                    $('.on_leave_window').mouseenter(function () {
-                        mw.cookie.set('<?php print $modal_id; ?>', 'yes');
-                        $('#popup-<?php print $params['id']; ?>').modal('show');
-                        $('.on_leave_window').remove();
-                    });
-                }, 5000);
-            });
-        </script>
-    <?php endif; ?>
-<?php endif; ?>
-
 
 <?php
+elseif ($type == 'on_leave_window'):
+	$session_get = false;
+	$modal_id = 'popup-' . $params['id'];
+	if (isset($_COOKIE['popup-' . $params['id']])) {
+		$session_get = $_COOKIE['popup-' . $params['id']];
+	}
+
+	if ($session_get != 'yes') {
+		$showPopUp = true;
+	} else {
+		$showPopUp = false;
+	}
+
+	if ($showPopUp): ?>
+	<style>
+		.on_leave_window {
+			z-index: 99999;
+			height: 2px;
+			top: 0;
+			width: 100%;
+			position: fixed;
+			/*border: 1px solid red;*/
+		}
+	</style>
+	<script>
+		$(document).ready(function () {
+			$('#popup-<?php print $params['id'];?>').hide();
+			setTimeout(function () {
+				$('body').append('<div class="on_leave_window"></div>');
+				$('.on_leave_window').mouseenter(function () {
+					mw.cookie.set('<?php print $modal_id; ?>', 'yes');
+					<?php if($source == 'existing_page' && !empty($page_id)): ?>
+					popup_get_content();
+					<?php endif;?>
+					$('#popup-<?php print $params['id']; ?>').modal('show');
+					$('.on_leave_window').remove();
+				});
+			}, 5000);
+		});
+	</script>
+	<?php endif;
+
+elseif ($type == 'on_click_host'):
+?>
+	<script type="text/javascript">
+		$(document).ready(function () {
+			var prev_a = $('#<?php print $params['id'];?>').prevAll().find('a:last');
+			if(typeof prev_a !== "undefined"){
+			    prev_a.prop('href', '#popup-<?php print $params['id']; ?>');
+			    <?php if($source == 'existing_page' && !empty($page_id)): ?>
+			    prev_a.click(function(){
+			        popup_get_content();
+			        $('#popup-<?php print $params['id']; ?>').modal('show');
+			    });
+			    <?php endif;?>
+			} else {
+				console.log('Popup module on_click_host error: previous a-tag not found');
+			}
+		});
+	</script>
+<?php
+endif;
+
+
+if($source == 'existing_page' && !empty($page_id)): ?>
+<script type="text/javascript">
+	function popup_get_content() {
+		$.ajax({
+			url: '<?php print api_url('popup_module_get_content_by_id') . '?page_id=' . $page_id; ?>',
+			type: 'GET',
+			success: function (data) {
+				$('#modal-title').html(data.title);
+				$('#modal-content').html(data.content);
+			},
+			error: function (XMLHttpRequest, textStatus, errorThrown) {
+				console.log(XMLHttpRequest);
+				console.log(textStatus);
+				console.log(errorThrown);
+			}
+		});
+	}
+</script>
+<?php endif;
+
+
 $module_template = get_option('data-template', $params['id']);
 if ($module_template == false and isset($params['template'])) {
     $module_template = $params['template'];
@@ -104,15 +154,17 @@ if (is_file($template_file) != false) {
 }
 ?>
 
-<?php print lnotif('Pop-Up Settings'); ?>
+<?php if ($type != 'on_click' && in_live_edit()) print lnotif('Pop-Up Settings'); ?>
 
 <?php if (in_live_edit()): ?>
     <style>
         #popup-<?php print $params['id']; ?> {
-            z-index: 900 !important;
+            z-index: 1102 !important;
             top: 10%;
         }
     </style>
+    <?php if ($type != 'on_click'): ?>
     <a class="btn btn-default pull-right" data-toggle="modal" href="#popup-<?php print $params['id']; ?>"
        data-backdrop="false" style="margin-top: -30px;">Open Pop-Up</a>
+    <?php endif; ?>
 <?php endif; ?>

--- a/userfiles/modules/popup/templates/default.php
+++ b/userfiles/modules/popup/templates/default.php
@@ -8,6 +8,8 @@ name: Default
 
 description: Default
 
+TODO: add option to show accept button instead of close
+
 */
 ?>
 <script>
@@ -15,31 +17,41 @@ description: Default
 </script>
 
 <div class="bootstrap3ns">
-    <?php if ($type == 'on_click'): ?>
-        <a data-toggle="modal" href="#popup-<?php print $params['id']; ?>" data-backdrop="false">Click to open modal</a>
+    <?php if ($type == 'on_click'):
+        $onclick = (($source == 'existing_page' && !empty($page_id))? 'onclick="return popup_get_content();"' : '');
+    ?>
+        <a id="#popup-link" <?php print $onclick;?> data-toggle="modal" href="#popup-<?php print $params['id']; ?>" data-backdrop="false"><?php print $link_text;?></a>
     <?php endif; ?>
 
-    <div class="modal fade" tabindex="-1" role="dialog" id="popup-<?php print $params['id']; ?>">
+    <div class="modal fade" tabindex="-1" role="dialog" id="popup-<?php print $params['id']; ?>" style="display:none">
         <div class="modal-dialog" role="document">
             <div class="modal-content">
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
                                 aria-hidden="true">&times;</span></button>
+					<?php if($source == 'existing_page'):?>
+					<h4 id="modal-title"></h4>
+					<?php else: ?>
                     <h4 class="modal-title edit" rel="module" field="module-popup-title-<?php print $params['id']; ?>">
                         Modal title</h4>
+                    <?php endif;?>
                 </div>
                 <div class="modal-body">
-                    <div style="max-height: 50vh; overflow-y: scroll;">
+                    <div style="max-height: 50vh; overflow-y: scroll; padding-right:15px">
+                        <?php if($source == 'existing_page'): ?>
+                              <div id="modal-content">loading ...</div>
+                        <?php else: ?>
                         <div class="edit allow-drop" rel="module"
                              field="module-popup-content-<?php print $params['id']; ?>">
                             <p>One fine body&hellip;</p>
                         </div>
+                        <?php endif;?>
                     </div>
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
 
-                    <?php if (in_live_edit()): ?>
+                    <?php if (in_live_edit() && $source != 'existing_page'): ?>
                         <button type="button" class="btn btn-success" onclick="mw.drag.save();">Save</button>
                     <?php endif; ?>
 


### PR DESCRIPTION
Extended popup module with the following features:
1) added option to set content source to be an existing page eg Terms & Conditions, Affiliate link disclosure, or Opinion Disclaimer
2) link text can now be set in settings
3) added 'On click host link' option to replace the nearest preceding link with the popup href

Changes to link_editor and rte_link_editor:
a) increased record limit from 4 to 20 - is a limit required for performance issues? Also noted that parameter is_active:'y' breaks the search.
b) added css overflow:auto; to #mw-popup-insertlink to allow selection of content title in dropdown. Also might be better if modal resized when dropdown opens. Would be good to preload with content title in the dropdown (as I've done for the popup module).
