### PR TITLE
Newsletter subscribe option for contact and registration forms

### DIFF
--- a/userfiles/modules/contact_form/index.php
+++ b/userfiles/modules/contact_form/index.php
@@ -135,10 +135,13 @@ $require_terms = get_option('require_terms', $params['module'] . '_default');
 $require_terms_when = '';
 
 if($require_terms) {
-    $user_id_or_email = (is_logged()? user_id():false);
-    if(mw()->user_manager->terms_check('terms_contact', $user_id_or_email)){
-    	$require_terms = 'n';
-    } else {
+    if(is_logged()){
+    	if(mw()->user_manager->terms_check('terms_contact', user_id())) {
+    	    $require_terms = 'n';
+    	}
+    }
+
+    if($require_terms) {
 		$require_terms_when = get_option('require_terms_when', $params['module'] . '_default');
 		if($require_terms_when == 'b') {
 			$terms_label = get_option('terms_label', 'users');
@@ -149,6 +152,16 @@ if($require_terms) {
 				$terms_label = 'I agree with the <a href="' . site_url() . 'terms" target="_blank">Terms and Conditions</a>';
 			}
 		}
+	}
+}
+
+$show_newsletter_subscription = get_option('newsletter_subscription', $params['module'] . '_default');
+if($show_newsletter_subscription == 'y') {
+	$newsletter_subscribed = false;
+	if(is_logged()){
+	    if(mw()->user_manager->terms_check('terms_newsletter', user_id())){
+		    $newsletter_subscribed = true;
+	    }
 	}
 }
 

--- a/userfiles/modules/contact_form/settings.php
+++ b/userfiles/modules/contact_form/settings.php
@@ -79,6 +79,15 @@ if (isset($params['for_module_id'])) {
 
 <hr>
 
+<div class="mw-ui-field-holder">
+    <label class="mw-ui-check">
+        <input type="checkbox" parent-reload="true" name="newsletter_subscription" value="y" data-value-unchecked="n" data-value-checked="y" class="mw_option_field" option-group="<?php print $mod_id ?>"
+            <?php if(get_option('newsletter_subscription', $mod_id)=='y'): ?> checked="checked" <?php endif; ?> />
+        <span></span><span><?php _e("Show newsletter subscription checkbox"); ?></span></label>
+</div>
+
+<hr>
+
 <module type="contact_form/privacy_settings"/>
 
 <?php if ($mod_id != 'contact_form_default') { ?>

--- a/userfiles/modules/contact_form/templates/default.php
+++ b/userfiles/modules/contact_form/templates/default.php
@@ -22,10 +22,28 @@
 
 <div class="contact-form-container contact-form-template-dream">
     <div class="contact-form">
+        <div class="edit" data-field="contact_form_title" rel="contact_form_module" data-id="<?php print $params['id'] ?>">
+            <h3 class="element contact-form-title"><?php _e("Leave a Message"); ?></h3>
+        </div>
         <form class="mw_form" data-form-id="<?php print $form_id ?>" name="<?php print $form_id ?>" method="post">
 
 
             <module type="custom_fields" for-id="<?php print $params['id'] ?>" data-for="module" default-fields="name,email,message"/>
+
+        <?php if($show_newsletter_subscription == 'y' && !$newsletter_subscribed): ?>
+            <div class="mw-flex-row">
+            	<div class="mw-flex-col-md-12 mw-flex-col-sm-12 mw-flex-col-xs-12">
+                    <div class="form-group">
+                        <div class="custom-control custom-checkbox">
+                            <label class="mw-ui-check" style="padding-top:0">
+                                <input type="checkbox" name="newsletter_subscribe" value="1" autocomplete="off"/> <span></span>
+                                <span><?php _e("Please email me your monthly news and special offers"); ?></span>
+                            </label>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        <?php endif; ?>
 
 		<?php if($require_terms && $require_terms_when == 'b'): ?>
             <module type="users/terms" data-for="contact_form_default" />

--- a/userfiles/modules/newsletter/functions/subscriber_functions.php
+++ b/userfiles/modules/newsletter/functions/subscriber_functions.php
@@ -152,7 +152,7 @@ function newsletter_subscribe($params)
     ];
     
     newsletter_save_subscriber($subscriber_data);
-    $msg = 'Thanks for your subscription!';
+    $msg = 'Thank you for subscribing!';
 
     $resp = array(
         'success' => $msg

--- a/userfiles/modules/newsletter/index.php
+++ b/userfiles/modules/newsletter/index.php
@@ -1,5 +1,7 @@
 <?php
 
+$require_terms = get_option('require_terms', $params['module']);
+
 if ($params['id'] == 'edit_template_iframe') {
 	include 'edit_template_iframe.php';
 	return;

--- a/userfiles/modules/newsletter/templates/default.php
+++ b/userfiles/modules/newsletter/templates/default.php
@@ -23,7 +23,7 @@ description: Default
                 <?php _e('Name'); ?>
                 <span class="asteriskField">*</span>
             </label>
-            <input class="form-control" name="name" placeholder="You Name" type="text"/>
+            <input class="form-control" required="true" name="name" placeholder="Your Name" type="text"/>
         </div>
 
         <div class="form-group hide-on-success">
@@ -31,7 +31,7 @@ description: Default
                 <?php _e('Email'); ?>
                 <span class="asteriskField">*</span> 
             </label>
-            <input class="form-control" name="email" placeholder="your@email.com" type="text"/>
+            <input class="form-control" required="true" name="email" placeholder="name@email.com" type="text"/>
         </div>
         
          <div class="form-group hide-on-success">
@@ -53,7 +53,13 @@ description: Default
 			<?php endif; ?>
 			</select>
         </div>
-        
+
+	<?php if($require_terms): ?>
+	 <div class="form-group hide-on-success">
+		<module type="users/terms" data-for="newsletter" />
+	    </div>
+	<?php endif; ?>
+
         <div class="form-group  hide-on-success">
             <div>
                 <button class="btn btn-primary " name="submit" type="submit">

--- a/userfiles/modules/newsletter/templates/small.php
+++ b/userfiles/modules/newsletter/templates/small.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+
+type: layout
+
+name: Small
+
+description: Small
+
+*/
+?>
+<style>
+#<?php print $params['id'] ?> {
+    max-width: 350px;
+    min-height: 260px;
+    background-color:#2c540b;
+    border-radius:4px;
+}
+#<?php print $params['id'] ?> h3 {
+    font-size:26px;
+    color:white;
+    padding:16px 4px 12px 4px;
+}
+#<?php print $params['id'] ?> .btn-default {
+    border:none;
+}
+#<?php print $params['id'] ?> label {
+    color: white;
+}
+#<?php print $params['id'] ?> .form-group {
+	margin:4px 20px 6px 20px;
+}
+#<?php print $params['id'] ?> input[type="text"] {
+    width:100%;
+}
+#<?php print $params['id'] ?> .control-label{
+	display:inline-block;
+	margin-top:8px;
+}
+#<?php print $params['id'] ?> .form-group .form-group {
+    margin:0;
+}
+#<?php print $params['id'] ?> a {
+	color: #8be827;
+}
+#<?php print $params['id'] ?> .btn-default {
+	margin-top: 2px;
+	padding: 10px 17px 10px 17px;
+}
+#<?php print $params['id'] ?> .module-users-terms {
+	margin-bottom:10px;
+}
+</style>
+
+<div class="newsletter-module-wrapper well">
+
+    <h3><?php _e('Subscribe for monthly news'); ?></h3>
+
+    <form method="post" id="newsletters-form-<?php print $params['id'] ?>">
+        <?php print csrf_form(); ?>
+
+         <div class="form-group hide-on-success">
+		    <div class="mw-flex-row">
+			    <div class="mw-flex-col-md-2 mw-flex-col-sm-12 mw-flex-col-xs-12">
+                    <label class="control-label" for="name">
+                        <?php _e('Name'); ?>
+                    </label>
+                </div>
+			    <div class="mw-flex-col-md-10 mw-flex-col-sm-12 mw-flex-col-xs-12">
+                    <input class="form-control" required="true" name="name" placeholder="Your Name" type="text"/>
+                </div>
+             </div>
+        </div>
+
+        <div class="form-group hide-on-success">
+		    <div class="mw-flex-row">
+			    <div class="mw-flex-col-md-2 mw-flex-col-sm-2 mw-flex-col-xs-12">
+					<label class="control-label" for="email">
+						<?php _e('Email'); ?>
+					</label>
+                </div>
+			    <div class="mw-flex-col-md-10 mw-flex-col-sm-10 mw-flex-col-xs-12">
+                    <input class="form-control" required="true" name="email" placeholder="name@email.com" type="text"/>
+                </div>
+            </div>
+        </div>
+
+        <div class="form-group hide-on-success">
+		    <div class="mw-flex-row">
+			    <div class="mw-flex-col-md-8 mw-flex-col-sm-8 mw-flex-col-xs-12">
+				<?php if($require_terms): ?>
+					<module type="users/terms" data-for="newsletter" />
+				<?php endif; ?>
+			    </div>
+			    <div class="mw-flex-col-md-4 mw-flex-col-sm-4 mw-flex-col-xs-12">
+					<div class="control-group">
+						   <module type="btn" button_action="submit" button_style="btn-default" button_text="<?php _e("Subscribe"); ?>"  />
+					</div>
+			    </div>
+			</div>
+	    </div>
+
+    </form>
+
+
+</div>

--- a/userfiles/modules/settings/group/users.php
+++ b/userfiles/modules/settings/group/users.php
@@ -42,6 +42,7 @@ $form_show_first_name = get_option('form_show_first_name', 'users');
 $form_show_last_name = get_option('form_show_last_name', 'users');
 $form_show_address = get_option('form_show_address', 'users');
 $form_show_password_confirmation = get_option('form_show_password_confirmation', 'users');
+$form_show_newsletter_subscription = get_option('form_show_newsletter_subscription', 'users');
 ?>
 
 <script type="text/javascript">
@@ -666,6 +667,14 @@ $form_show_password_confirmation = get_option('form_show_password_confirmation',
                     <label class="mw-ui-check">
                         <input type="checkbox" value="y" <?php if ($form_show_password_confirmation == 'y'): ?> checked <?php endif; ?> name="form_show_password_confirmation" class="mw_option_field" option-group="users">
                         <span></span> <span><?php _e("Show password confirmation field?"); ?></span>
+                    </label>
+
+                     <br/>
+                     <br/>
+
+                    <label class="mw-ui-check">
+                         <input type="checkbox" value="y" <?php if ($form_show_newsletter_subscription == 'y'): ?> checked <?php endif; ?> name="form_show_newsletter_subscription" class="mw_option_field" option-group="users">
+                         <span></span> <span><?php _e("Show newsletter subscription checkbox?"); ?></span>
                     </label>
                 </div>
             </div>

--- a/userfiles/modules/users/register/index.php
+++ b/userfiles/modules/users/register/index.php
@@ -70,6 +70,32 @@
     }
 
 
+	$require_terms = get_option('require_terms', 'users');
+	$terms_and_conditions_name = 'terms_user';
+	if($require_terms) {
+		$user_id_or_email = (is_logged()? user_id():false);
+		if(mw()->user_manager->terms_check($terms_and_conditions_name, $user_id_or_email)){
+			$require_terms = 'n';
+		} else {
+			$terms_label = get_option('terms_label', 'users');
+			$terms_label_cleared = str_replace('&nbsp;', '', $terms_label);
+			$terms_label_cleared = strip_tags($terms_label_cleared);
+			$terms_label_cleared = mb_trim($terms_label_cleared);
+			if ($terms_label_cleared == '') {
+				$terms_label = 'I agree with the <a href="' . site_url() . 'terms" target="_blank">Terms and Conditions</a>';
+			}
+		}
+	}
+
+    $show_newsletter_subscription = get_option('form_show_newsletter_subscription', 'users');
+    if($show_newsletter_subscription == 'y') {
+		$newsletter_subscribed = false;
+		$user_id_or_email = (is_logged()? user_id():false);
+		if(mw()->user_manager->terms_check('terms_newsletter', $user_id_or_email)){
+			$newsletter_subscribed = true;
+		}
+    }
+
     $module_template = get_option('data-template', $params['id']);
     if ($module_template == false and isset($params['template'])) {
         $module_template = $params['template'];

--- a/userfiles/modules/users/register/templates/default.php
+++ b/userfiles/modules/users/register/templates/default.php
@@ -104,29 +104,6 @@ description: Default register template
 
             <div class="alert" style="margin: 0;display: none;"></div>
 
-            <?php if ($have_social_login): ?>
-            <div class="social-login">
-                <h5><?php _e("Login with"); ?>:</h5>
-                    <ul>
-                        <?php if ($facebook): ?>
-                            <li><a href="<?php print api_link('user_social_login?provider=facebook') ?>" class="mw-signin-with-facebook">Facebook login</a></li>
-                        <?php endif; ?>
-                        <?php if ($twitter): ?>
-                            <li><a href="<?php print api_link('user_social_login?provider=twitter') ?>" class="mw-signin-with-twitter">Twitter login</a></li>
-                        <?php endif; ?>
-                        <?php if ($google): ?>
-                            <li><a href="<?php print api_link('user_social_login?provider=google') ?>" class="mw-signin-with-google">Google login</a></li>
-                        <?php endif; ?>
-                        <?php if ($windows): ?>
-                            <li><a href="<?php print api_link('user_social_login?provider=live') ?>" class="mw-signin-with-live">Windows login</a></li>
-                        <?php endif; ?>
-                        <?php if ($github): ?>
-                            <li><a href="<?php print api_link('user_social_login?provider=github') ?>" class="mw-signin-with-github">Github login</a></li>
-                        <?php endif; ?>
-                    </ul>
-            </div>
-            <?php endif; ?>
-
             <button type="submit" class="btn btn-default pull-right"><?php print $form_btn_title ?></button>
 
             <div style="clear: both"></div>

--- a/userfiles/modules/users/register/templates/default.php
+++ b/userfiles/modules/users/register/templates/default.php
@@ -34,10 +34,7 @@ description: Default register template
 <div class="module-register well">
     <div class="box-head">
         <h2>
-            <?php _e("New Registration or"); ?>
-            <a href="<?php print login_url(); ?>">
-                <?php _e("Login"); ?>
-            </a>
+            <?php _e("New Registration"); ?>
         </h2>
     </div>
     <div id="register_form_holder">
@@ -45,17 +42,10 @@ description: Default register template
 
             <?php print csrf_form(); ?>
 
-
-            <div class="control-group form-group">
-                <div class="controls">
-                    <input type="text" class="large-field form-control" name="email" placeholder="<?php _e("Email"); ?>">
-                </div>
-            </div>
-
             <?php if ($form_show_first_name): ?>
                 <div class="control-group form-group">
                     <div class="controls">
-                        <input type="text" class="large-field form-control" name="first_name" placeholder="<?php _e("First name"); ?>">
+                        <input type="text" class="large-field form-control" name="first_name" placeholder="<?php _e("First name"); ?>" required>
                     </div>
                 </div>
 
@@ -64,38 +54,59 @@ description: Default register template
             <?php if ($form_show_last_name): ?>
                 <div class="control-group form-group">
                     <div class="controls">
-                        <input type="text" class="large-field form-control" name="last_name" placeholder="<?php _e("Last name"); ?>">
+                        <input type="text" class="large-field form-control" name="last_name" placeholder="<?php _e("Last name"); ?>" required>
                     </div>
                 </div>
 
             <?php endif; ?>
+            <div class="control-group form-group">
+                <div class="controls">
+                    <input type="text" class="large-field form-control" name="email" placeholder="<?php _e("Email"); ?>" required>
+                </div>
+            </div>
 
             <div class="control-group form-group">
                 <div class="controls">
-                    <input type="password" class="large-field form-control" name="password" placeholder="<?php _e("Password"); ?>">
+                    <input type="password" class="large-field form-control" name="password" placeholder="<?php _e("Password"); ?>" required>
                 </div>
             </div>
 
             <?php if ($form_show_password_confirmation): ?>
                 <div class="control-group form-group">
                     <div class="controls">
-                        <input type="password" class="large-field form-control" name="password2" placeholder="<?php _e("Repeat password"); ?>">
+                        <input type="password" class="large-field form-control" name="password2" placeholder="<?php _e("Confirm password"); ?>" required>
                     </div>
                 </div>
             <?php endif; ?>
 
+            <?php if($show_newsletter_subscription == 'y' && !$newsletter_subscribed): ?>
+			<div class="control-group form-group">
+				<div class="custom-control custom-checkbox">
+					<label class="mw-ui-check">
+						<input type="checkbox" name="newsletter_subscribe" value="1" autocomplete="off"/> <span></span>
+						<span><?php _e("Please email me your monthly news and special offers"); ?></span>
+					</label>
+				</div>
+			</div>
+            <?php endif; ?>
 
+		    <?php if($require_terms): ?>
+                <module type="users/terms" data-for="registration" />
+            <?php endif; ?>
+
+			<?php if (get_option('disable_captcha', $params['id']) != 'y'): ?>
             <div class="mw-ui-row vertical-middle captcha-row">
                 <div class="mw-ui-col">
                     <module type="captcha"/>
                 </div>
             </div>
+			<?php endif; ?>
 
             <div class="alert" style="margin: 0;display: none;"></div>
 
+            <?php if ($have_social_login): ?>
             <div class="social-login">
-                <?php if ($have_social_login) { ?><h5><?php _e("Login with"); ?>:</h5><?php } ?>
-                <?php if ($have_social_login): ?>
+                <h5><?php _e("Login with"); ?>:</h5>
                     <ul>
                         <?php if ($facebook): ?>
                             <li><a href="<?php print api_link('user_social_login?provider=facebook') ?>" class="mw-signin-with-facebook">Facebook login</a></li>
@@ -113,8 +124,8 @@ description: Default register template
                             <li><a href="<?php print api_link('user_social_login?provider=github') ?>" class="mw-signin-with-github">Github login</a></li>
                         <?php endif; ?>
                     </ul>
-                <?php endif; ?>
             </div>
+            <?php endif; ?>
 
             <button type="submit" class="btn btn-default pull-right"><?php print $form_btn_title ?></button>
 

--- a/userfiles/modules/users/terms/index.php
+++ b/userfiles/modules/users/terms/index.php
@@ -14,7 +14,7 @@ if ($terms_label_cleared == '') {
             <div class="custom-control custom-checkbox">
                 <!-- <h5><?php _e('You must agree to the Terms and Conditions to continue'); ?></h5> //-->
                 <label class="mw-ui-check">
-                    <input type="checkbox" name="terms" class="i_agree_with_terms_input" value="1" autocomplete="off"/> <span></span><span><?php print $terms_label; ?></span>
+                    <input type="checkbox" name="terms" required="true" class="i_agree_with_terms_input" value="1" autocomplete="off"/> <span></span><span><?php print $terms_label; ?></span>
                 </label>
             </div>
         </div>


### PR DESCRIPTION
We want to allow users to subscribe to our newsletter on the contact form and at registration for marketing. These proposed updates add the option to include a subscribe checkbox below the last fields in both the contact and registration forms and above the agree terms checkbox if that exists. 