### PR TITLE
Video module lazyload update

### DIFF
--- a/userfiles/modules/video/admin.php
+++ b/userfiles/modules/video/admin.php
@@ -211,9 +211,23 @@
                                 </label>
                             </div>
 
-                            <hr/>
-
-                            <h5>Upload Thumbnail</h5>
+                        </div>
+                    </div>
+                    <div class="mw-accordion-item">
+                        <div class="mw-ui-box-header mw-accordion-title">
+                            <div class="header-holder">
+                                <i class="mai-setting2"></i> Video SEO
+                            </div>
+                        </div>
+                        <div class="mw-accordion-content mw-ui-box mw-ui-box-content">
+                            <h5>Video Lazy Loading for SEO</h5>
+                            <div class="mw-ui-field-holder">
+                                <label class="mw-ui-check">
+                                    <input id="chk_lazyload" name="lazyload" class="mw-ui-field mw_option_field" type="checkbox" data-mod-name="<?php print $params['data-type'] ?>" value="y" <?php if (get_option('lazyload', $params['id']) == 'y') { ?> checked='checked' <?php } ?>/>
+                                    <span></span>
+                                    <span><?php _e("Lazy load"); ?></span>
+                                </label>
+                            </div>
                             <div class="mw-ui-field-holder">
                                 <label class="mw-ui-label"><?php _e("Upload Video Thumbnail from your computer"); ?>
                                     <br>

--- a/userfiles/modules/video/admin.php
+++ b/userfiles/modules/video/admin.php
@@ -131,7 +131,7 @@
                     <div class="mw-accordion-item">
                         <div class="mw-ui-box-header mw-accordion-title">
                             <div class="header-holder">
-                                <i class="mai-setting2"></i> Embed Video
+                                <i class="mai-setting2"></i>Embed Video
                             </div>
                         </div>
                         <div class="mw-accordion-content mw-ui-box mw-ui-box-content">
@@ -210,46 +210,62 @@
                                     <span><?php _e("Autoplay"); ?></span>
                                 </label>
                             </div>
-
                         </div>
                     </div>
+
                     <div class="mw-accordion-item">
                         <div class="mw-ui-box-header mw-accordion-title">
                             <div class="header-holder">
-                                <i class="mai-setting2"></i> Video SEO
+                                <i class="mai-setting2"></i>Upload Thumbnail
                             </div>
                         </div>
                         <div class="mw-accordion-content mw-ui-box mw-ui-box-content">
-                            <h5>Video Lazy Loading for SEO</h5>
-                            <div class="mw-ui-field-holder">
-                                <label class="mw-ui-check">
-                                    <input id="chk_lazyload" name="lazyload" class="mw-ui-field mw_option_field" type="checkbox" data-mod-name="<?php print $params['data-type'] ?>" value="y" <?php if (get_option('lazyload', $params['id']) == 'y') { ?> checked='checked' <?php } ?>/>
-                                    <span></span>
-                                    <span><?php _e("Lazy load"); ?></span>
-                                </label>
-                            </div>
                             <div class="mw-ui-field-holder">
                                 <label class="mw-ui-label"><?php _e("Upload Video Thumbnail from your computer"); ?>
                                     <br>
-                                    <small><?php _e("Optional setting to reduce page size for YouTube videos"); ?>
+                                    <small><?php _e("Optional thumbnail image for use with uploaded or embedded videos. Required if Lazy Loading selected."); ?>
                                     </small>
                                 </label>
 
                                 <div class="row" style="margin-top:10px;">
                                     <div class="col-xs-6">
                                         <input name="upload_thumb" id="upload_thumb_field" class="mw-ui-field mw_option_field semi_hidden" type="text" data-mod-name="<?php print $params['data-type'] ?>" value="<?php print get_option('upload_thumb', $params['id']) ?>"/>
-                                        <span class="mw-ui-btn mw-ui-btn-info" id="upload_thumb_btn"><span class="fas fa-upload"></span> &nbsp; <?php _e("Browse Video Screenshot"); ?></span>
+                                        <span class="mw-ui-btn mw-ui-btn-info" id="upload_thumb_btn"><span class="fas fa-upload"></span> &nbsp; <?php _e("Choose thumbnail image"); ?></span>
                                     </div>
                                     <div class="col-xs-6">
                                         <img id="thumb" src="<?php print thumbnail(get_option('upload_thumb', $params['id']), 100, 100); ?>" alt=""/>
                                         <input id="upload_thumb" name="upload_thumb" class="mw-ui-field mw_option_field" type="hidden" data-mod-name="<?php print $params['data-type'] ?>" value=""/>
                                     </div>
                                 </div>
-                            </div>
+                             </div>
 
                             <div class="mw-ui-progress" id="upload_thumb_status" style="display: none">
                                 <div style="width: 0%" class="mw-ui-progress-bar"></div>
                                 <div class="mw-ui-progress-info"><?php _e("Status"); ?>: <span class="mw-ui-progress-percent">0</span></div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="mw-accordion-item">
+                        <div class="mw-ui-box-header mw-accordion-title">
+                            <div class="header-holder">
+                                <i class="mai-setting2"></i>Video Lazy Loading
+                            </div>
+                        </div>
+                        <div class="mw-accordion-content mw-ui-box mw-ui-box-content">
+                            <div class="mw-ui-field-holder">
+                                <label class="mw-ui-label"><?php _e("Video Lazy Loading for SEO"); ?>
+                                    <br>
+                                    <small><?php _e("Optional setting for use with embedded YouTube videos to defer the downloading of video scripts. Thumbnail image required, see Thumbnail Upload section."); ?>
+                                    </small>
+                                </label>
+                                <div class="row" style="margin-top:10px;">
+                                    <div class="mw-ui-check col-xs-6">
+                                        <input id="chk_lazyload" name="lazyload" class="mw-ui-field mw_option_field" type="checkbox" data-mod-name="<?php print $params['data-type'] ?>" value="y" <?php if (get_option('lazyload', $params['id']) == 'y') { ?> checked='checked' <?php } ?>/>
+                                        <span></span>
+                                        <span><?php _e("Lazy load"); ?></span>
+                                    </div>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/userfiles/modules/video/config.php
+++ b/userfiles/modules/video/config.php
@@ -5,7 +5,7 @@ $config['name'] = "Video";
 $config['author'] = "Microweber";
 $config['categories'] = "recommended,media";
 $config['position'] = 6;
-$config['version'] = 0.1;
+$config['version'] = 0.2;
 
 $config['no_cache'] = false;
 $config['ui'] = true;

--- a/userfiles/modules/video/config.php
+++ b/userfiles/modules/video/config.php
@@ -4,10 +4,6 @@ $config = array();
 $config['name'] = "Video";
 $config['author'] = "Microweber";
 $config['categories'] = "recommended,media";
-
-
-
-
 $config['position'] = 6;
 $config['version'] = 0.1;
 

--- a/userfiles/modules/video/functions.php
+++ b/userfiles/modules/video/functions.php
@@ -90,3 +90,10 @@ function video_module_is_embed($str)
         return false;
     }
 }
+
+
+api_expose('video_lazyload');
+function video_lazyload()
+{
+    return urldecode($_POST['html_code']);
+}

--- a/userfiles/modules/video/index.php
+++ b/userfiles/modules/video/index.php
@@ -9,6 +9,12 @@ if ($code == false) {
     }
 }
 
+$enable_full_page_cache = get_option('enable_full_page_cache','website');
+
+$lazyload = get_option('lazyload', $params['id']);
+
+$lazyload = ((!empty($lazyload) && $lazyload == 'y')? true : false);
+
 $upload = get_option('upload', $params['id']);
 
 $thumb = get_option('upload_thumb', $params['id']);
@@ -40,7 +46,7 @@ if ($autoplay == false) {
     }
 }
 if ($w == '') {
-    $w = '100%';
+    $w = '450';
 }
 if ($h == '') {
     $h = '350';
@@ -51,7 +57,6 @@ if ($autoplay == '') {
 if($upload and !$code){
     $prior = 2;
 }
-
 
 
 $module_template = get_option('data-template', $params['id']);
@@ -68,7 +73,6 @@ if ($module_template != false) {
 if (is_file($template_file)) {
     include($template_file);
 }
-
 
 if(!$upload and !$code){
     print  lnotif('Click to edit video');

--- a/userfiles/modules/video/templates/default.php
+++ b/userfiles/modules/video/templates/default.php
@@ -51,10 +51,33 @@ if($show_video_settings_btn) {
         $code = "<div class='video-module-default-view mw-open-module-settings'><img src='" . $config['url_to_module'] . "video.svg' style='width: 65px; height: 65px;'/></div>";
     }
 } else {
-	if($use_thumbnail) {
+	if($lazyload && $use_thumbnail) {
 		$unique_id = str_replace('-','',$params['id']);
-		$css = '<style>.video-player{background: #000;}.video-player img:hover{cursor: pointer;}</style>' . "\n";
-		$script = '<script>function replaceImg' . $unique_id . '(img){var div = document.createElement("div");div.innerHTML = \'' . $code . '\';img.parentNode.replaceChild(div, img);}</script>' . "\n";
+		$css = '<style>.video-player{text-align:center;background: #000;}.video-player img:hover{cursor: pointer;}</style>' . "\n";
+		if($enable_full_page_cache){
+			// use ajax to return decoded html instead of using only js to avoid issues with full page cache and innerHTML value
+			$script = '<script type="application/javascript">' .
+			'function replaceImg' . $unique_id . '(img){' .
+				'$.ajax({' .
+					'url: \'' . api_url('video_lazyload') .'\',' .
+					'data: {html_code: \'' . urlencode($code) . '\'},' .
+					'type: \'POST\',' .
+					'dataType: \'html\',' .
+					'success: function (response) {' .
+						'var div = document.createElement("div");' .
+						'div.innerHTML = response;' .
+						'img.parentNode.replaceChild(div, img);' .
+					'},' .
+					'error: function (XMLHttpRequest, textStatus, errorThrown) {' .
+						'console.log(XMLHttpRequest);' .
+						'console.log(textStatus);' .
+						'console.log(errorThrown);' .
+					'}' .
+				'});' .
+			'}</script>' . "\n";
+		} else {
+			$script = '<script>function replaceImg' . $unique_id . '(img){var div = document.createElement("div");div.innerHTML = \'' . $code . '\';img.parentNode.replaceChild(div, img);}</script>' . "\n";
+		}
 		$code = $css . $script . '<div class="video-player"><img onclick="javascript:replaceImg' . $unique_id . '(this);" src="' . $thumb . '"></div>';
 	}
 }


### PR DESCRIPTION
The current admin settings for the video module show the 'Upload Thumbnail' option within the 'Upload Video' accordian. However before accordians, this option was intended for use with embeded YouTube videos and the lazyload setting; so that a light weight placeholder thumbnail image would initially be loaded and the heavier weight YouTube scripts would be defered until the video was clicked, thereby reducing page size.

In this proposed update, I've moved the thumbnail upload to it's own accordian because it works with either an uploaded video or with and embedded video with lazyload selected. The lazyload setting I've added to an accordian below.

I found the lazyloading script failed when using the experimental Full Page Cache, it didn't like html being set in the innerHTML property. As a workaround if Full Page Cache is set, I've encoded the html in the js and decoded it via an ajax call; Someone else may have a better solution! 