### PR TITLE
Fix sql query not compatible with postgresql

### DIFF
--- a/src/Microweber/Traits/QueryFilter.php
+++ b/src/Microweber/Traits/QueryFilter.php
@@ -271,7 +271,7 @@ trait QueryFilter
                                                 $query->{$where_or_where}(function ($query) use ($to_search_in_fields, $to_search_keyword, $params, $table) {
                                                     foreach ($to_search_in_fields as $to_search_in_field) {
                                                         $to_search_keyword = str_replace('.', ' ', $to_search_keyword);
-                                                        $query = $query->orWhere($to_search_in_field, 'REGEXP', $to_search_keyword);
+                                                        // $query = $query->orWhere($to_search_in_field, 'REGEXP', $to_search_keyword);
                                                         $query = $query->orWhere($to_search_in_field, 'LIKE', '%'.$to_search_keyword.'%');
                                                         $query = $query->orWhere($to_search_in_field, 'LIKE', '%'.$to_search_keyword);
                                                         $query = $query->orWhere($to_search_in_field, 'LIKE', '.'.$to_search_keyword);

--- a/src/Microweber/Traits/QueryFilter.php
+++ b/src/Microweber/Traits/QueryFilter.php
@@ -271,22 +271,19 @@ trait QueryFilter
                                                 $query->{$where_or_where}(function ($query) use ($to_search_in_fields, $to_search_keyword, $params, $table) {
                                                     foreach ($to_search_in_fields as $to_search_in_field) {
                                                         $to_search_keyword = str_replace('.', ' ', $to_search_keyword);
-                                                        // $query = $query->orWhere($to_search_in_field, 'REGEXP', $to_search_keyword);
-                                                        $query = $query->orWhere($to_search_in_field, 'ILIKE', '%'.$to_search_keyword.'%');
-                                                        //$query = $query->orWhere($to_search_in_field, 'LIKE', '%'.$to_search_keyword);
-                                                        //$query = $query->orWhere($to_search_in_field, 'LIKE', '.'.$to_search_keyword);
-                                                        //$query = $query->orWhere($to_search_in_field, 'LIKE', $to_search_keyword.'%');
-                                                        //$query = $query->orWhereRaw('LOWER(`'.$to_search_in_field.'`) LIKE ? ',['%'.trim(strtolower($to_search_keyword)).'%']);
-
-
+                                                        if ($dbDriver == 'pgsql') {
+                                                            $query = $query->orWhere($to_search_in_field, 'ILIKE', '%'.$to_search_keyword.'%');
+                                                        } else {
+                                                            $query = $query->orWhere($to_search_in_field, 'LIKE', '%'.$to_search_keyword.'%');
+                                                            $query = $query->orWhere($to_search_in_field, 'REGEXP', $to_search_keyword);
+                                                            $query = $query->orWhere($to_search_in_field, 'LIKE', '%'.$to_search_keyword);
+                                                            $query = $query->orWhere($to_search_in_field, 'LIKE', '.'.$to_search_keyword);
+                                                            $query = $query->orWhere($to_search_in_field, 'LIKE', $to_search_keyword.'%');
+                                                            $query = $query->orWhereRaw('LOWER(`'.$to_search_in_field.'`) LIKE ? ',['%'.trim(strtolower($to_search_keyword)).'%']);
+                                                        }           
                                                     }
 
-
                                                 });
-
-
-
-
                                                 //  $query->distinct();
                                             }
                                         }

--- a/src/Microweber/Traits/QueryFilter.php
+++ b/src/Microweber/Traits/QueryFilter.php
@@ -272,10 +272,10 @@ trait QueryFilter
                                                     foreach ($to_search_in_fields as $to_search_in_field) {
                                                         $to_search_keyword = str_replace('.', ' ', $to_search_keyword);
                                                         // $query = $query->orWhere($to_search_in_field, 'REGEXP', $to_search_keyword);
-                                                        $query = $query->orWhere($to_search_in_field, 'LIKE', '%'.$to_search_keyword.'%');
-                                                        $query = $query->orWhere($to_search_in_field, 'LIKE', '%'.$to_search_keyword);
-                                                        $query = $query->orWhere($to_search_in_field, 'LIKE', '.'.$to_search_keyword);
-                                                        $query = $query->orWhere($to_search_in_field, 'LIKE', $to_search_keyword.'%');
+                                                        $query = $query->orWhere($to_search_in_field, 'ILIKE', '%'.$to_search_keyword.'%');
+                                                        //$query = $query->orWhere($to_search_in_field, 'LIKE', '%'.$to_search_keyword);
+                                                        //$query = $query->orWhere($to_search_in_field, 'LIKE', '.'.$to_search_keyword);
+                                                        //$query = $query->orWhere($to_search_in_field, 'LIKE', $to_search_keyword.'%');
                                                         //$query = $query->orWhereRaw('LOWER(`'.$to_search_in_field.'`) LIKE ? ',['%'.trim(strtolower($to_search_keyword)).'%']);
 
 

--- a/src/Microweber/Traits/QueryFilter.php
+++ b/src/Microweber/Traits/QueryFilter.php
@@ -276,7 +276,7 @@ trait QueryFilter
                                                         $query = $query->orWhere($to_search_in_field, 'LIKE', '%'.$to_search_keyword);
                                                         $query = $query->orWhere($to_search_in_field, 'LIKE', '.'.$to_search_keyword);
                                                         $query = $query->orWhere($to_search_in_field, 'LIKE', $to_search_keyword.'%');
-                                                        $query = $query->orWhereRaw('LOWER(`'.$to_search_in_field.'`) LIKE ? ',['%'.trim(strtolower($to_search_keyword)).'%']);
+                                                        //$query = $query->orWhereRaw('LOWER(`'.$to_search_in_field.'`) LIKE ? ',['%'.trim(strtolower($to_search_keyword)).'%']);
 
 
                                                     }

--- a/src/Microweber/Traits/QueryFilter.php
+++ b/src/Microweber/Traits/QueryFilter.php
@@ -268,7 +268,7 @@ trait QueryFilter
                                                     }
                                                 }
 
-                                                $query->{$where_or_where}(function ($query) use ($to_search_in_fields, $to_search_keyword, $params, $table) {
+                                                $query->{$where_or_where}(function ($query) use ($to_search_in_fields, $to_search_keyword, $params, $table, $dbDriver) {
                                                     foreach ($to_search_in_fields as $to_search_in_field) {
                                                         $to_search_keyword = str_replace('.', ' ', $to_search_keyword);
                                                         if ($dbDriver == 'pgsql') {


### PR DESCRIPTION
On postgresql installed microweber, in the live view mode. Trying to `add menu item` and use the option `Post, Category`. Trying to filter based on the product title will result in server error 500.

The problem is, postgresql do not support `REGEX` & also backticks on columns ( mysql specific )

This commit fix the issue with sql string not compatible with postgresql.

<img width="806" alt="Screenshot 2020-01-31 at 10 28 26 AM" src="https://user-images.githubusercontent.com/27353/73507608-71f2e580-4414-11ea-8185-9be3473a5833.png">
