### PR TITLE
Enable font fallback

### DIFF
--- a/userfiles/modules/microweber/api/libs/mw-ui/grunt/plugins/ui/css/bootstrap_variables.scss
+++ b/userfiles/modules/microweber/api/libs/mw-ui/grunt/plugins/ui/css/bootstrap_variables.scss
@@ -44,11 +44,8 @@ $font-size-sm: $font-size-base * .875 !default;
 
 $small-font-size: 12px !default;
 
-$font-family-sans-serif: 'Verdana' !default;
-$font-family-monospace: 'Verdana' !default;
-
-$font-family-sans-serif: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji" !default;
-$font-family-monospace: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace !default;
+$font-family-sans-serif: 'Verdana', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji" !default;
+$font-family-monospace: 'Verdana', SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace !default;
 
 $font-family-base: $font-family-sans-serif !default;
 


### PR DESCRIPTION
On systems where Verdana is not installed, the admin panel looks really ugly (everything in serif-font, like Time New Roman)

This re-enabled the font fallback.

Remarks: I do not know how to build the .css file, this of course has to be rebuild