### PR TITLE
fix: Contact form export only contains latest entry

### DIFF
--- a/src/MicroweberPackages/Form/FormsManager.php
+++ b/src/MicroweberPackages/Form/FormsManager.php
@@ -62,7 +62,6 @@ class FormsManager
         }
 
         $data = $this->app->database_manager->get($params);
-        $findFormsDataValues = FormDataValue::where('form_data_id', $data)->get();
 
         $ret = array();
         if (is_array($data)) {
@@ -74,6 +73,7 @@ class FormsManager
                 }
                 if (empty($item['form_values'])) {
                     $fields = [];
+                    $findFormsDataValues = FormDataValue::where('form_data_id', $item)->get();
                     if ($findFormsDataValues->count() > 0) {
                         foreach ($findFormsDataValues as $formsDataValue) {
                             if (is_array($formsDataValue->field_value_json) && !empty($formsDataValue->field_value_json)) {


### PR DESCRIPTION
When using the contact form export, the correct number of rows would be present in the exported documents, but all rows would contain the information of the latest entry only.
This PR fixes that.