### PR TITLE
Fixed Validation Bug for Special Price: Exceeds Main Price and Non-Numeric Check

### DIFF
--- a/src/MicroweberPackages/Product/Http/Requests/ProductRequest.php
+++ b/src/MicroweberPackages/Product/Http/Requests/ProductRequest.php
@@ -8,7 +8,16 @@ use MicroweberPackages\Product\Models\Product;
 class ProductRequest extends ContentSaveRequest
 {
     public $model = Product::class;
-
+    public function withValidator($validator)
+    {
+        $validator->after(function ($validator) {
+            $mainPrice = $this->input('price');
+            $specialPrice = $this->input('content_data.special_price');
+            if ($specialPrice !== null && $specialPrice > $mainPrice) {
+                $validator->errors()->add('content_data.special_price', 'Special price must not be greater than the main price.');
+            }
+        });
+    }
     public $rules = [
         'title' => 'required|max:500',
         'url' => 'max:500',
@@ -16,6 +25,8 @@ class ProductRequest extends ContentSaveRequest
         'content_meta_keywords' => 'max:500',
         'original_link' => 'max:500',
         //'price' => 'required|min:0.01|numeric',
+        'price' => 'required|min:0|numeric',
+        'content_data.special_price' => 'nullable|numeric',
         'qty' => 'max:50',
         'sku' => 'max:500',
         'content_data.barcode' => 'max:200',


### PR DESCRIPTION
This pull request addresses issue #1073 by fixing the validation bug related to the special price field in the "Add New Product" feature. The validation now properly checks if the special price exceeds the main price and ensures that it is also numeric. This enhancement ensures accurate and consistent validation of pricing data, improving the reliability of the application.

![offer price](https://github.com/microweber/microweber/assets/44068019/5feb0a3e-ab3d-4303-a14f-e5861c202af3)


![textprice](https://github.com/microweber/microweber/assets/44068019/f9d3d350-c145-4523-9099-c028a7fb5b4e)
