### PR TITLE
Fix shipping tests - implement proper driver registration

### DIFF
--- a/Modules/Shipping/Drivers/FlatRate.php
+++ b/Modules/Shipping/Drivers/FlatRate.php
@@ -20,7 +20,7 @@ class FlatRate extends AbstractShippingMethod
         if (!$model) {
             return 0;
         }
-        $shipping_cost = $model->settings['shipping_cost'] ? floatval($model->settings['shipping_cost']) : 0;
+        $shipping_cost = isset($model->settings['shipping_cost']) ? floatval($model->settings['shipping_cost']) : 0;
         return $shipping_cost;
     }
 

--- a/Modules/Shipping/Tests/Unit/Drivers/FlatRateTest.php
+++ b/Modules/Shipping/Tests/Unit/Drivers/FlatRateTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Modules\Shipping\Tests\Unit\Drivers;
+
+use PHPUnit\Framework\Attributes\Test;
+use Modules\Shipping\Drivers\FlatRate;
+use Modules\Shipping\Models\ShippingProvider;
+use Tests\TestCase;
+
+class FlatRateTest extends TestCase
+{
+    #[Test]
+    public function testFlatRateInitialization()
+    {
+        $flatRate = new FlatRate();
+        $this->assertEquals('Flat Rate', $flatRate->title());
+    }
+
+    #[Test]
+    public function testDefaultShippingCost()
+    {
+        $flatRate = new FlatRate();
+        $model = new ShippingProvider();
+        $model->settings = [];
+        $flatRate->setModel($model);
+        $this->assertEquals(0, $flatRate->getShippingCost());
+    }
+
+    #[Test]
+    public function testCustomShippingCost()
+    {
+        $flatRate = new FlatRate();
+        $model = new ShippingProvider();
+        $model->settings = ['shipping_cost' => 15];
+        $flatRate->setModel($model);
+        $this->assertEquals(15, $flatRate->getShippingCost());
+    }
+
+    #[Test]
+    public function testSettingsHandling()
+    {
+        $flatRate = new FlatRate();
+        $model = new ShippingProvider();
+        $model->settings = [
+            'shipping_cost' => 20,
+            'shipping_instructions' => 'Fragile items'
+        ];
+        $flatRate->setModel($model);
+        $this->assertEquals(20, $flatRate->getShippingCost());
+    }
+
+    
+}

--- a/Modules/Shipping/Tests/Unit/Drivers/PickupFromAddressTest.php
+++ b/Modules/Shipping/Tests/Unit/Drivers/PickupFromAddressTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Modules\Shipping\Tests\Unit\Drivers;
+
+use PHPUnit\Framework\Attributes\Test;
+use Modules\Shipping\Drivers\PickupFromAddress;
+use Tests\TestCase;
+
+class PickupFromAddressTest extends TestCase
+{
+    #[Test]
+    public function testPickupInitialization()
+    {
+        $pickup = new PickupFromAddress();
+        $this->assertEquals('Pickup From Address', $pickup->title());
+    }
+
+    #[Test]
+    public function testDefaultAddress()
+    {
+        $pickup = new PickupFromAddress();
+        $this->assertEmpty($pickup->settings['address'] ?? '');
+    }
+
+    #[Test]
+    public function testCustomAddress()
+    {
+        $pickup = new PickupFromAddress();
+        $pickup->settings = ['address' => '123 Main St, City'];
+        $this->assertEquals('123 Main St, City', $pickup->settings['address']);
+    }
+
+    #[Test]
+    public function testSettingsHandling()
+    {
+        $pickup = new PickupFromAddress();
+        $pickup->settings = [
+            'address' => '456 Commerce Ave',
+            'pickup_hours' => '9am-5pm'
+        ];
+
+        $this->assertEquals('456 Commerce Ave', $pickup->settings['address']);
+    }
+
+    #[Test]
+    public function testCalculateCostIsAlwaysZero()
+    {
+        $pickup = new PickupFromAddress();
+        $this->assertEquals(0, $pickup->getShippingCost());
+
+        $pickup->settings = ['address' => '123 Main St'];
+        $this->assertEquals(0, $pickup->getShippingCost());
+    }
+}

--- a/Modules/Shipping/Tests/Unit/Drivers/ShippingToCountryTest.php
+++ b/Modules/Shipping/Tests/Unit/Drivers/ShippingToCountryTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Modules\Shipping\Tests\Unit\Drivers;
+
+use PHPUnit\Framework\Attributes\Test;
+use Modules\Shipping\Drivers\ShippingToCountry;
+use Tests\TestCase;
+
+class ShippingToCountryTest extends TestCase
+{
+    #[Test]
+    public function testDriverInitialization()
+    {
+        $driver = new ShippingToCountry();
+        $this->assertEquals('Shipping to Country', $driver->title());
+    }
+
+    #[Test]
+    public function testDefaultCountryRates()
+    {
+        $driver = new ShippingToCountry();
+        $this->assertEmpty($driver->settings['country_rates'] ?? []);
+    }
+
+    #[Test]
+    public function testSettingCountryRates()
+    {
+        $driver = new ShippingToCountry();
+        $driver->settings = [
+            'country_rates' => [
+                'US' => 15,
+                'CA' => 20
+            ]
+        ];
+
+        $this->assertEquals(15, $driver->settings['country_rates']['US']);
+        $this->assertEquals(20, $driver->settings['country_rates']['CA']);
+    }
+
+    #[Test]
+    public function testCountryRatesConfiguration()
+    {
+        $driver = new ShippingToCountry();
+        $driver->settings = [
+            'country_rates' => [
+                'US' => 10,
+                'UK' => 15
+            ]
+        ];
+
+        $this->assertEquals(10, $driver->settings['country_rates']['US']);
+        $this->assertEquals(15, $driver->settings['country_rates']['UK']);
+    }
+}

--- a/Modules/Shipping/Tests/Unit/ShippingMethodManagerTest.php
+++ b/Modules/Shipping/Tests/Unit/ShippingMethodManagerTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Modules\Shipping\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\Test;
+use Modules\Shipping\Services\ShippingMethodManager;
+use Modules\Shipping\Drivers\FlatRate;
+use Modules\Shipping\Drivers\PickupFromAddress;
+use Modules\Shipping\Drivers\ShippingToCountry;
+use Modules\Shipping\Models\ShippingProvider;
+use Tests\TestCase;
+
+class ShippingMethodManagerTest extends TestCase
+{
+    protected $manager;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        
+        $this->manager = app(ShippingMethodManager::class);
+        $this->manager->extend('flat_rate', function() {
+            return new FlatRate();
+        });
+        $this->manager->extend('pickup_from_address', function() {
+            return new PickupFromAddress();
+        });
+        $this->manager->extend('shipping_to_country', function() {
+            return new ShippingToCountry();
+        });
+    }
+
+    #[Test]
+    public function testManagerInitialization()
+    {
+        $this->assertInstanceOf(ShippingMethodManager::class, $this->manager);
+    }
+
+    #[Test]
+    public function testDriverRegistration()
+    {
+        // Test registration of each driver type
+        $this->assertTrue($this->manager->driverExists('flat_rate'));
+        $this->assertTrue($this->manager->driverExists('pickup_from_address'));
+        $this->assertTrue($this->manager->driverExists('shipping_to_country'));
+    }
+
+    #[Test]
+    public function testCalculateShippingCostWithProvider()
+    {
+        $provider = ShippingProvider::create([
+            'name' => 'Test Provider',
+            'provider' => 'flat_rate', 
+            'is_active' => true,
+            'settings' => ['shipping_cost' => 15]
+        ]);
+        
+        $cost = $this->manager->getShippingCost($provider->id, []);
+        $this->assertEquals(15, $cost);
+    }
+}

--- a/Modules/Shipping/Tests/Unit/ShippingModuleTest.php
+++ b/Modules/Shipping/Tests/Unit/ShippingModuleTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Modules\Shipping\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\Test;
+use Modules\Shipping\Models\ShippingProvider;
+use Modules\Shipping\Services\ShippingMethodManager;
+use Modules\Shipping\Drivers\FlatRate;
+use Modules\Shipping\Drivers\PickupFromAddress;
+use Tests\TestCase;
+
+class ShippingModuleTest extends TestCase
+{
+    protected $manager;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        
+        $this->manager = app(ShippingMethodManager::class);
+        $this->manager->extend('flat_rate', function() {
+            return new FlatRate();
+        });
+        $this->manager->extend('pickup_from_address', function() {
+            return new PickupFromAddress();
+        });
+    }
+
+    #[Test]
+    public function testShippingProviderCreation()
+    {
+        $provider = ShippingProvider::create([
+            'name' => 'Test Provider',
+            'provider' => 'flat_rate',
+            'is_active' => true,
+            'settings' => ['cost' => 10]
+        ]);
+
+        $this->assertDatabaseHas('shipping_providers', [
+            'name' => 'Test Provider',
+            'provider' => 'flat_rate'
+        ]);
+    }
+
+    #[Test]
+    public function testShippingManagerRegistration()
+    {
+        $this->assertInstanceOf(ShippingMethodManager::class, $this->manager);
+    }
+
+    #[Test]
+    public function testFlatRateDriver()
+    {
+        $driver = $this->manager->driver('flat_rate');
+        $this->assertInstanceOf(FlatRate::class, $driver);
+        $this->assertEquals('Flat Rate', $driver->title());
+    }
+
+    #[Test]
+    public function testPickupFromAddressDriver()
+    {
+        $driver = $this->manager->driver('pickup_from_address');
+        $this->assertInstanceOf(PickupFromAddress::class, $driver);
+        $this->assertEquals('Pickup From Address', $driver->title());
+    }
+}

--- a/Modules/Shipping/Tests/Unit/ShippingProviderTest.php
+++ b/Modules/Shipping/Tests/Unit/ShippingProviderTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Modules\Shipping\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\Test;
+use Modules\Shipping\Models\ShippingProvider;
+use Tests\TestCase;
+
+class ShippingProviderTest extends TestCase
+{
+    #[Test]
+    public function testCanCreateShippingProvider()
+    {
+        $provider = ShippingProvider::create([
+            'name' => 'Test Provider',
+            'provider' => 'flat_rate',
+            'is_active' => true,
+            'settings' => ['cost' => 15]
+        ]);
+
+        $this->assertEquals('Test Provider', $provider->name);
+        $this->assertEquals('flat_rate', $provider->provider);
+        $this->assertTrue($provider->is_active);
+        $this->assertEquals(['cost' => 15], $provider->settings);
+    }
+
+    #[Test]
+    public function testProviderSettingsAreCastToArray()
+    {
+        $provider = ShippingProvider::create([
+            'name' => 'Test Cast',
+            'provider' => 'pickup_from_address',
+            'settings' => ['address' => '123 Main St']
+        ]);
+
+        $this->assertIsArray($provider->settings);
+        $this->assertEquals('123 Main St', $provider->settings['address']);
+    }
+
+    #[Test]
+    public function testActiveProviders()
+    {
+        // Clear existing providers
+        ShippingProvider::truncate();
+
+        ShippingProvider::create([
+            'name' => 'Active Provider',
+            'provider' => 'flat_rate',
+            'is_active' => true
+        ]);
+
+        ShippingProvider::create([
+            'name' => 'Inactive Provider',
+            'provider' => 'pickup_from_address',
+            'is_active' => false
+        ]);
+
+        $activeProviders = ShippingProvider::where('is_active', true)->get();
+        $this->assertCount(1, $activeProviders);
+        $this->assertEquals('Active Provider', $activeProviders->first()->name);
+    }
+}


### PR DESCRIPTION
This PR fixes the shipping module tests by:
- Properly registering drivers in test setup
- Using persistent manager instances
- Adding precise assertions
- Fixing cost calculation logic