### PR TITLE
#1159 - Added check for mbstring extension

### DIFF
--- a/index.php
+++ b/index.php
@@ -24,6 +24,10 @@ if (!function_exists('gd_info')) {
     exit('Error: GD PHP extension is required to run Microweber');
 }
 
+if (!function_exists('mb_convert_encoding')) {
+    exit('Error: MBString PHP extension is required to run Microweber');
+}
+
 if (!class_exists('PDO') ) {
     exit('Error: PDO PHP extension is required to run Microweber');
 }


### PR DESCRIPTION
If PHP mbstring extension is not installed, the run fails with 500 error and not much info. This PR adds check for the presence of mbstring extension, in a similar manner to checks for PDO, GD. OpenSSL, etc.