### PR TITLE
fix: physical_product checkbox is broken

### DIFF
--- a/userfiles/modules/content/views/product/shipping.php
+++ b/userfiles/modules/content/views/product/shipping.php
@@ -10,10 +10,10 @@
                 <div class="col-md-12 ps-md-0">
                     <div class="form-group">
                         <div class="custom-control custom-checkbox my-2">
-                            <input x-model="physicalProduct" type="checkbox" class="form-check-input" id="customCheck4"
-                                   name="content_data[physical_product]" value="1">
                             <input type="hidden" class="form-check-input"
                                    name="content_data[physical_product]" value="0">
+                            <input x-model="physicalProduct" type="checkbox" class="form-check-input" id="customCheck4"
+                                   name="content_data[physical_product]" value="1">
                             <label class="custom-control-label" for="customCheck4"><?php _e("This is a physical product"); ?></label>
                         </div>
                     </div>
@@ -117,6 +117,10 @@
                     </div>
 
                 </div>
+            </div>
+
+            <div x-show="!physicalProduct">
+                <?php include_once __DIR__ .'/digital.php'; ?>
             </div>
         </div>
     </div>

--- a/userfiles/modules/content/views/product/shipping.php
+++ b/userfiles/modules/content/views/product/shipping.php
@@ -12,6 +12,8 @@
                         <div class="custom-control custom-checkbox my-2">
                             <input x-model="physicalProduct" type="checkbox" class="form-check-input" id="customCheck4"
                                    name="content_data[physical_product]" value="1">
+                            <input type="hidden" class="form-check-input"
+                                   name="content_data[physical_product]" value="0">
                             <label class="custom-control-label" for="customCheck4"><?php _e("This is a physical product"); ?></label>
                         </div>
                     </div>


### PR DESCRIPTION
while editing a Product, if you check the "This is a physical product" checkbox, there is no going back to a digital product. this is because the checkbox is submitted only if checked and otherwise is not submitted, and Laravel does not update the Product model with the inteded value (zero)

fix: added a hidden field that fills the checkbox gap and makes it update the model in case it's unchecked