### PR TITLE
security: add allowed_classes => false to unserialize() in FieldsManager and UrlManager

### DIFF
--- a/src/MicroweberPackages/CustomField/FieldsManager.php
+++ b/src/MicroweberPackages/CustomField/FieldsManager.php
@@ -654,7 +654,7 @@ class FieldsManager
                 if (isset($it['values']) and is_string($it['values'])) {
                     $try = base64_decode($it['values']);
                     if ($try != false and strlen($try) > 5) {
-                        $it['values'] = unserialize($try);
+                        $it['values'] = unserialize($try, ['allowed_classes' => false]);
                     }
                     if (isset($it['values']['value'])) {
                         $temp = $it['values']['value'];

--- a/src/MicroweberPackages/Helper/UrlManager.php
+++ b/src/MicroweberPackages/Helper/UrlManager.php
@@ -201,7 +201,7 @@ class UrlManager
                         $params_list = explode(',', $the_param);
                         if ($param == 'custom_fields_criteria') {
                             $the_param1 = base64_decode($the_param);
-                            $the_param1 = unserialize($the_param1);
+                            $the_param1 = unserialize($the_param1, ['allowed_classes' => false]);
 
                             return $the_param1;
                         }


### PR DESCRIPTION
## Summary

Two `unserialize()` calls in Microweber deserialize data without an `allowed_classes` restriction. PHP's `unserialize()` will instantiate any class in the autoloader when no restriction is given, which opens the door to PHP Object Injection (POI).

## Affected files

### `FieldsManager::decodeArrayVals()`
Custom field option values are stored base64-encoded in the database and decoded/unserialized here. The data is expected to be a plain PHP array (a list of dropdown options). There's no reason for objects here — `allowed_classes => false` is safe and blocks POI for any attacker who can influence the stored field value.

### `UrlManager` — `custom_fields_criteria`
This one is more serious. The value is base64-decoded **directly from a URL parameter** — fully attacker-controlled, no authentication needed. Without `allowed_classes`, crafting a URL with a serialized object payload can trigger a gadget chain during `unserialize()`, potentially leading to RCE.

## Fix

Added `['allowed_classes' => false]` to both calls. For valid data (plain arrays), this has zero behavior change. For object payloads, `unserialize()` returns `__PHP_Incomplete_Class` instead of instantiating the object.