### PR TITLE
Fix unauthenticated path traversal / arbitrary file read in ServeStaticFileContoller (CVE-2026-65694)

### DIFF
--- a/src/MicroweberPackages/App/Http/Controllers/ServeStaticFileContoller.php
+++ b/src/MicroweberPackages/App/Http/Controllers/ServeStaticFileContoller.php
@@ -19,10 +19,19 @@ class ServeStaticFileContoller extends Controller
      */
     public function serveFromUserfiles(Request $request)
     {
-        $path = $request->path;
+        // Use the bound route segment, NOT the input property. $request->path resolves via
+        // Request::__get to the request input, so a ?path= query string overrides the {path}
+        // route segment and enables path traversal. Confine the result to userfiles_path().
+        $requested = (string) $request->route('path');
 
+        $base = realpath(userfiles_path());
+        $path = realpath(normalize_path($base . DIRECTORY_SEPARATOR . $requested, false));
 
-        $path = normalize_path(userfiles_path() . $path, false);
+        abort_if(
+            $base === false || $path === false
+            || strncmp($path, $base . DIRECTORY_SEPARATOR, strlen($base) + 1) !== 0,
+            404
+        );
 
         return $this->sendResponse($path, $request);
 


### PR DESCRIPTION
## Security fix: unauthenticated path traversal / arbitrary file read in `GET /userfiles/{path}`

**Severity:** High — CVSS 3.1 7.5 (`AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N`) · CWE-22 · CVE-2026-65694

### The problem

`ServeStaticFileContoller::serveFromUserfiles()` reads the path from a **request input property** instead of the bound route segment:

```php
$path = $request->path;   // property access
```

In Laravel, `$request->path` (property, not the `->path()` method) resolves via `Request::__get` to `Arr::get($this->all(), 'path', fn() => $this->route('path'))`, so a **`?path=` query string overrides the `{path}` route segment**. `normalize_path()` does not strip `..`, and the `api.static` route group has no authentication middleware. An unauthenticated attacker can read any file the web-server user can reach.

### Reproduction (no cookie, no auth header)

On the shipped public-docroot layout (`public/.htaccess` front controller / recommended nginx `try_files $uri /index.php`), `userfiles/` is outside the docroot so the request reaches Laravel:

```bash
curl -i 'http://TARGET/userfiles/x?path=../.env'
# 200 OK -> APP_KEY=..., MAIL_PASSWORD=..., AWS_SECRET_ACCESS_KEY=...

curl -i 'http://TARGET/userfiles/x?path=../../../../../../etc/passwd'
# 200 OK -> root:x:0:0:...
```

Leaking `.env` exposes the `APP_KEY` (session/cookie forgery), DB credentials, mail password and cloud keys.

### The fix (this PR)

Read the **bound route parameter** (`$request->route('path')`) instead of the input property, then canonicalize with `realpath()` and verify the resolved path stays inside `userfiles_path()`:

```php
$requested = (string) $request->route('path');
$base = realpath(userfiles_path());
$path = realpath(normalize_path($base . DIRECTORY_SEPARATOR . $requested, false));
abort_if($base === false || $path === false
    || strncmp($path, $base . DIRECTORY_SEPARATOR, strlen($base) + 1) !== 0, 404);
```

Assigned **CVE-2026-65694**. Reported by Bobur Abdugafforov (Mahadsec). Tested only against a local instance.
